### PR TITLE
Migrate to `generic-exporter`  charmhub listing 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-[![Generic Exporter Charm](https://charmhub.io/generic-exporter-operator/badge.svg)](https://charmhub.io/generic-exporter-operator)
+[![Generic Exporter Charm](https://charmhub.io/generic-exporter/badge.svg)](https://charmhub.io/generic-exporter)
 
 # Generic Exporter Operator
 
 ## Overview
 
-[Charmhub Page](https://charmhub.io/generic-exporter-operator)
+[Charmhub Page](https://charmhub.io/generic-exporter)
 
 The Generic Exporter Operator is a Juju charm that deploys and manages any snap that provides a Prometheus exporter. It is designed to be flexible and configurable, allowing users to specify the snap name, version, and configuration options.
 

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -2,7 +2,7 @@
 # See LICENSE file for licensing details.
 
 type: charm
-name: generic-exporter-operator
+name: generic-exporter
 title: Generic Exporter
 summary: |
   A generic, configurable exporter charm that sets up an exporter from a snap and exports metrics and dashboard via COS relation.
@@ -20,7 +20,7 @@ links:
   source:
   - https://github.com/canonical/generic-exporter-operator
   website:
-  - https://charmhub.io/generic-exporter-operator
+  - https://charmhub.io/generic-exporter
   - https://github.com/canonical/generic-exporter-operator
 
 subordinate: true


### PR DESCRIPTION
The PR migrates from `https://charmhub.io/generic-exporter-operator` to `https://charmhub.io/generic-exporter`.

Blocked by the [charmhub request](https://discourse.charmhub.io/t/create-new-track-for-generic-exporter/19988) to add the required tracks.