### PR TITLE
fix: allow generic-exporter to relate to more than one principal application 

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -133,4 +133,3 @@ requires:
       `juju-info` provides basic compatibility with all charms.
     interface: juju-info
     scope: container
-    limit: 1

--- a/src/charm.py
+++ b/src/charm.py
@@ -113,6 +113,7 @@ class GenericExporterOperatorCharm(ops.CharmBase):
         """Reconcile the charm state."""
         try:
             self._validate_config()
+            self._check_colocated_units()
 
             if self.conf.snap_name not in self.get_installed_snap_names:
                 self._log_and_set_status(ops.MaintenanceStatus("Installing charm resources"))
@@ -173,6 +174,21 @@ class GenericExporterOperatorCharm(ops.CharmBase):
             raise CharmInstallError(
                 f"Failed to start snap services for: {self.conf.snap_name}. "
                 "See juju debug-log for details."
+            )
+
+    def _check_colocated_units(self) -> None:
+        """Raise CharmConfigError if another unit of this app is co-located on this machine.
+
+        Raises:
+            CharmConfigError: If a co-located unit of the same app is detected.
+        """
+        if self.conf.snap_name and self.singleton_manager.is_colocated_with_same_app(
+            self.conf.snap_name, self.app.name
+        ):
+            raise CharmConfigError(
+                "Another unit of this application is co-located on this machine. "
+                "A single exporter-port config cannot serve multiple "
+                "principals on the same machine."
             )
 
     def _check_status(self) -> None:

--- a/src/snap_singleton.py
+++ b/src/snap_singleton.py
@@ -229,3 +229,27 @@ class SingletonSnapManager:
     def is_used_by_other_units(self, snap_name: str) -> bool:
         """Check if the specified snap is being used by other units."""
         return any(unit != self.unit_name for unit in self._get_units(snap_name))
+
+    def is_colocated_with_same_app(self, snap_name: str, app_name: str) -> bool:
+        """Check if another unit of the same Juju application is registered for this snap.
+
+        This detects the case where two principals of the same subordinate app are
+        co-located on one machine — a single exporter-port config cannot serve both.
+
+        Note: this only guards against same-app co-location. If two *different*
+        generic-exporter apps request the same snap name on the same machine they
+        may conflict on snap revision.
+
+        Args:
+            snap_name: Name of the snap to check.
+            app_name: Juju application name of the current unit.
+
+        Returns:
+            True if another unit of the same app is already registered for this snap.
+        """
+        normalized_app_prefix = SnapRegistrationFile._normalize_name(app_name) + "_"
+        normalized_self = SnapRegistrationFile._normalize_name(self.unit_name)
+        return any(
+            u.startswith(normalized_app_prefix) and u != normalized_self
+            for u in self._get_units(snap_name)
+        )

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -13,7 +13,7 @@ TIMEOUT = 10 * 60
 
 UBUNTU_CHANNEL = "latest/stable"
 UBUNTU_APP_NAME = "ubuntu"
-UBUNTU_APP_NAME_2 = "ubuntu-2"
+UBUNTU_APP_NAME_2 = "ubuntu-two"
 OTCOL_APP = "opentelemetry-collector"
 OTCOL_CHANNEL = "2/stable"
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -13,6 +13,7 @@ TIMEOUT = 10 * 60
 
 UBUNTU_CHANNEL = "latest/stable"
 UBUNTU_APP_NAME = "ubuntu"
+UBUNTU_APP_NAME_2 = "ubuntu-2"
 OTCOL_APP = "opentelemetry-collector"
 OTCOL_CHANNEL = "2/stable"
 

--- a/tests/integration/test_multiple_principals.py
+++ b/tests/integration/test_multiple_principals.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Integration tests for relating one generic-exporter app to multiple principals.
+
+Scenario: one generic-exporter app is related to two separate principal applications
+each deployed on their own machine. Each principal should receive its own subordinate
+unit and both should reach active/idle.
+
+This validates that the charm works without a `limit: 1` constraint on the juju-info
+relation endpoint.
+"""
+
+import logging
+
+import jubilant
+from helpers import (
+    JUJU_INFO_ENDPOINT,
+    SMARTCTL_EXPORTER_PORT,
+    SMARTCTL_SNAP_NAME,
+    TIMEOUT,
+    UBUNTU_APP_NAME,
+    UBUNTU_APP_NAME_2,
+    UBUNTU_CHANNEL,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def test_deploy_multiple_principals(
+    juju: jubilant.Juju, charm: str, app_name: str, base: str
+) -> None:
+    """Deploy one generic-exporter app related to two different principal apps."""
+    juju.deploy(
+        charm,
+        app=app_name,
+        base=base,
+        config={
+            "snap-name": SMARTCTL_SNAP_NAME,
+            "exporter-port": SMARTCTL_EXPORTER_PORT,
+        },
+    )
+    juju.deploy(UBUNTU_APP_NAME, channel=UBUNTU_CHANNEL, base=base)
+    juju.deploy(app=UBUNTU_APP_NAME_2, charm="ubuntu", channel=UBUNTU_CHANNEL, base=base)
+
+    juju.integrate(f"{app_name}:{JUJU_INFO_ENDPOINT}", f"{UBUNTU_APP_NAME}:{JUJU_INFO_ENDPOINT}")
+    juju.integrate(f"{app_name}:{JUJU_INFO_ENDPOINT}", f"{UBUNTU_APP_NAME_2}:{JUJU_INFO_ENDPOINT}")
+
+    juju.wait(
+        lambda status: jubilant.all_active(status, app_name, UBUNTU_APP_NAME, UBUNTU_APP_NAME_2),
+        error=jubilant.any_error,
+        timeout=TIMEOUT,
+    )
+
+
+def test_two_subordinate_units_created(juju: jubilant.Juju, app_name: str) -> None:
+    """Assert that one subordinate unit exists on each principal machine."""
+    status = juju.status()
+    exporter_units = status.get_units(app_name)
+
+    assert len(exporter_units) == 2, (
+        f"Expected 2 generic-exporter subordinate units (one per principal), "
+        f"got {len(exporter_units)}: {list(exporter_units.keys())}"
+    )
+
+
+def test_each_subordinate_active(juju: jubilant.Juju, app_name: str) -> None:
+    """Assert that every subordinate unit is active/idle."""
+    status = juju.status()
+    exporter_units = status.get_units(app_name)
+
+    for unit_name, unit in exporter_units.items():
+        assert unit.workload_status.current == "active", (
+            f"Unit {unit_name} is not active: {unit.workload_status}"
+        )
+
+
+def test_remove_multiple_principals(juju: jubilant.Juju, app_name: str) -> None:
+    """Clean up all applications deployed in this module."""
+    juju.remove_application(app_name)
+    juju.remove_application(UBUNTU_APP_NAME, destroy_storage=True)
+    juju.remove_application(UBUNTU_APP_NAME_2, destroy_storage=True)
+
+    juju.wait(
+        lambda status: app_name not in status.apps,
+        timeout=TIMEOUT,
+    )

--- a/tests/integration/test_multiple_principals.py
+++ b/tests/integration/test_multiple_principals.py
@@ -16,7 +16,10 @@ import logging
 
 import jubilant
 from helpers import (
+    COS_ENDPOINT,
     JUJU_INFO_ENDPOINT,
+    OTCOL_APP,
+    OTCOL_CHANNEL,
     SMARTCTL_EXPORTER_PORT,
     SMARTCTL_SNAP_NAME,
     TIMEOUT,
@@ -41,9 +44,11 @@ def test_deploy_multiple_principals(
             "exporter-port": SMARTCTL_EXPORTER_PORT,
         },
     )
+    juju.deploy(OTCOL_APP, channel=OTCOL_CHANNEL, base=base)
     juju.deploy(UBUNTU_APP_NAME, channel=UBUNTU_CHANNEL, base=base)
     juju.deploy(app=UBUNTU_APP_NAME_2, charm="ubuntu", channel=UBUNTU_CHANNEL, base=base)
 
+    juju.integrate(f"{app_name}:{COS_ENDPOINT}", f"{OTCOL_APP}:{COS_ENDPOINT}")
     juju.integrate(f"{app_name}:{JUJU_INFO_ENDPOINT}", f"{UBUNTU_APP_NAME}:{JUJU_INFO_ENDPOINT}")
     juju.integrate(f"{app_name}:{JUJU_INFO_ENDPOINT}", f"{UBUNTU_APP_NAME_2}:{JUJU_INFO_ENDPOINT}")
 
@@ -79,6 +84,7 @@ def test_each_subordinate_active(juju: jubilant.Juju, app_name: str) -> None:
 def test_remove_multiple_principals(juju: jubilant.Juju, app_name: str) -> None:
     """Clean up all applications deployed in this module."""
     juju.remove_application(app_name)
+    juju.remove_application(OTCOL_APP, destroy_storage=True)
     juju.remove_application(UBUNTU_APP_NAME, destroy_storage=True)
     juju.remove_application(UBUNTU_APP_NAME_2, destroy_storage=True)
 

--- a/tests/integration/test_scaling.py
+++ b/tests/integration/test_scaling.py
@@ -21,6 +21,13 @@ from helpers import (
 logger = logging.getLogger(__name__)
 
 
+def _one_active_one_blocked(status: jubilant.Status, app_name: str) -> bool:
+    """Return True when an app has exactly one active unit and one blocked unit."""
+    units = status.get_units(app_name)
+    statuses = [u.workload_status.current for u in units.values()]
+    return statuses.count("active") == 1 and statuses.count("blocked") == 1
+
+
 def test_deploy(juju: jubilant.Juju, charm: str, app_name: str, base: str) -> None:
     """Test that the charm deploys and relates correctly."""
     juju.deploy(
@@ -49,14 +56,22 @@ def test_scale_up(juju: jubilant.Juju, app_name: str) -> None:
     juju.add_unit(UBUNTU_APP_NAME, to="0")
 
     juju.wait(
-        lambda status: jubilant.all_active(status, app_name, UBUNTU_APP_NAME),
+        lambda status: (
+            jubilant.all_active(status, UBUNTU_APP_NAME)
+            and _one_active_one_blocked(status, app_name)
+        ),
         error=jubilant.any_error,
         timeout=TIMEOUT,
     )
 
+    ge_units = juju.status().get_units(app_name)
+    blocked = [n for n, u in ge_units.items() if u.workload_status.current == "blocked"]
+    assert len(blocked) == 1, f"Expected exactly one blocked subordinate unit, got: {blocked}"
+
+    # The blocked unit must not have written a lockfile (guard fires before register())
     principal_unit = get_app_unit(juju, UBUNTU_APP_NAME)
     task = juju.exec("ls /opt/singleton_snaps | wc -l", unit=principal_unit)
-    assert task.stdout.strip() == "2", "Expected 2 files in /opt/singleton_snaps"
+    assert task.stdout.strip() == "1", "Blocked unit must not register a lockfile"
 
 
 def test_scale_down(juju: jubilant.Juju, app_name: str) -> None:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -46,6 +46,7 @@ def mock_get_snap_info():
 def mock_singleton_snap_manager():
     """Mock the SingletonSnapManager class in charm.py."""
     mock_manager = MagicMock()
+    mock_manager.is_colocated_with_same_app.return_value = False
     with patch("charm.SingletonSnapManager", return_value=mock_manager):
         yield mock_manager
 
@@ -200,6 +201,27 @@ def test_snap_revision_not_found(mock_get_snap_info):
     assert state_out.unit_status == testing.BlockedStatus(
         "Could not determine revision for snap test-snap on channel stable."
     )
+
+
+def test_blocked_when_colocated_units(
+    mock_snap_client,
+    mock_singleton_snap_manager,
+    mock_get_snap_info,
+):
+    """Charm sets BlockedStatus when another unit of the same app is co-located on the machine."""
+    ctx = testing.Context(GenericExporterOperatorCharm)
+    mock_get_snap_info.return_value = DEFAULT_SNAP_INFO
+    mock_singleton_snap_manager.is_colocated_with_same_app.return_value = True
+
+    state_out = ctx.run(
+        ctx.on.install(),
+        testing.State(
+            config={"snap-name": "test-snap", "exporter-port": 9090, "snap-channel": "stable"}
+        ),
+    )
+
+    assert state_out.unit_status.name == "blocked"
+    assert "co-located" in state_out.unit_status.message
 
 
 def test_snap_classic_not_allowed(mock_get_snap_info):

--- a/tests/unit/test_snap_singleton.py
+++ b/tests/unit/test_snap_singleton.py
@@ -227,7 +227,7 @@ def test_is_colocated_with_same_app_false_only_self():
 
 
 def test_is_colocated_with_same_app_false_different_app():
-    """Different-app units on the same machine are not flagged (cross-app is a separate concern)."""
+    """Different-app units on the same machine are not flagged."""
     snap_name = "node-exporter"
     manager_a = SingletonSnapManager("app-alpha/0")
     manager_b = SingletonSnapManager("app-beta/0")

--- a/tests/unit/test_snap_singleton.py
+++ b/tests/unit/test_snap_singleton.py
@@ -192,3 +192,46 @@ def test_ignore_unexpected_files(lock_dir, caplog):
         "unexpected format" in record.message and "unexpected-file" in record.message
         for record in caplog.records
     )
+
+
+def test_is_colocated_with_same_app_true():
+    """Detect co-location when another unit of the same app is already registered."""
+    snap_name = "node-exporter"
+    app_name = "my-exporter"
+    manager_0 = SingletonSnapManager("my-exporter/0")
+    manager_1 = SingletonSnapManager("my-exporter/1")
+
+    manager_0.register(snap_name, 1)
+
+    assert manager_1.is_colocated_with_same_app(snap_name, app_name) is True
+
+
+def test_is_colocated_with_same_app_false_no_registrations():
+    """No co-location when nothing is registered on the machine yet."""
+    snap_name = "node-exporter"
+    app_name = "my-exporter"
+    manager_0 = SingletonSnapManager("my-exporter/0")
+
+    assert manager_0.is_colocated_with_same_app(snap_name, app_name) is False
+
+
+def test_is_colocated_with_same_app_false_only_self():
+    """No co-location when only the current unit is registered."""
+    snap_name = "node-exporter"
+    app_name = "my-exporter"
+    manager_0 = SingletonSnapManager("my-exporter/0")
+
+    manager_0.register(snap_name, 1)
+
+    assert manager_0.is_colocated_with_same_app(snap_name, app_name) is False
+
+
+def test_is_colocated_with_same_app_false_different_app():
+    """Different-app units on the same machine are not flagged (cross-app is a separate concern)."""
+    snap_name = "node-exporter"
+    manager_a = SingletonSnapManager("app-alpha/0")
+    manager_b = SingletonSnapManager("app-beta/0")
+
+    manager_a.register(snap_name, 1)
+
+    assert manager_b.is_colocated_with_same_app(snap_name, "app-beta") is False


### PR DESCRIPTION
Fixes #33 

## Issue
The `juju-info` endpoint had a `limit: 1` constraint (was part of the initial charm scaffolding). This prevented a single generic-exporter application from being related to more than one principal application.

## Solution
1- removing the limit alone should allows to relate to diff principal charms.
2- add a guard that puts the charm in blocked state if multiple generic-x units from the _same app_ are co-located on a single machine
- although juju allows that behavior, IMO, it doesnt make sense for this charm (especially if the exporter is scraping a workload not the host) since the snap config (scraping address, exporter port, .etc) is app-scoped not unit-scoped

## Possible future enhancements
- if 2 diff gen-x _apps_ happen to be co-located on the same machine and both name the same snap at different revision, we should have similar [snap revision conflict handling](https://github.com/canonical/opentelemetry-collector-operator/blob/ca72b32466d43e6c4c5e7169e0b910519cc194dc/src/charm.py#L566) as in otel-collector 

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 


